### PR TITLE
Fix error from SetupDiGetDeviceInterfaceDetail() on 32 bit

### DIFF
--- a/userspace/lib/usbip_setupdi.c
+++ b/userspace/lib/usbip_setupdi.c
@@ -112,7 +112,7 @@ get_intf_detail(HDEVINFO dev_info, PSP_DEVINFO_DATA pdev_info_data, LPCGUID pgui
 		return NULL;
 	}
 
-	pdev_interface_detail->cbSize = sizeof(PSP_DEVICE_INTERFACE_DETAIL_DATA);
+	pdev_interface_detail->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
 
 	// Try to get device details.
 	if (!SetupDiGetDeviceInterfaceDetail(dev_info, &dev_interface_data,


### PR DESCRIPTION
Use the structure, not the pointer to it. We were "lucky" it was working
properly.

This should fix get_intf_detail() on 32 bit where
SetupDiGetDeviceInterfaceDetail() would fail with error 0x6f8
ERROR_INVALID_USER_BUFFER
https://github.com/cezuni/usbip-win/issues/17

Signed-off-by: Alexandre Demers <alexandre.f.demers@gmail.com>