### PR TITLE
Update README.md and update to latest WDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USB/IP for Windows
 
-- This project aims to support both a USBIP server and a client on Windows platform.
+- This project aims to support both a USB/IP server and a client on Windows platform.
 
 
 ## Build
@@ -27,15 +27,15 @@
 
 ## Install
 
-### Usbip server
+### Windows USB/IP server
 
-- Prepare a linux machine as a USBIP client
-  - tested on Ubuntu 16.04
-  - Kernel 4.15.0-29 (usbip kernel module crash was observed on some other version)
+- Prepare a linux machine as a USB/IP client
+  - Tested on Ubuntu 16.04
+  - Kernel 4.15.0-29 (USB/IP kernel module crash was observed on some other version)
   - \# modprobe vhci-hcd
 
-- Install USBIP test certificate
-  - Install driver/usbip\_test.pfx(password: usbip)
+- Install USB/IP test certificate
+  - Install driver/usbip\_test.pfx (password: usbip)
   - Certificate should be installed into "Trusted Root Certification Authority" and "Trusted Publishers"
     on local machine (not current user)
 - Enable test signing
@@ -45,49 +45,51 @@
   - You can find usbip.exe, usbipd.exe, usbip\_stub.sys in output folder.
   - userspace/usb.ids
   - driver/stub/usbip\_stub.inx
-- Find usb device id
+- Find USB device id
   - You can get device id from usbip listing
-    - &lt;target dir&gt;\usbip.exe list -l
+    - usbip.exe list -l
   - Bus id is always 1. So output from usbip.exe listing is shown as:
 
 <pre><code>
-    C:\work\usbip.exe list -l
+    usbip.exe list -l
       - busid 1-59 (045e:00cb)
         Microsoft Corp. : Basic Optical Mouse v2.0 (045e:00cb)
       - busid 1-30 (80ee:0021)
         VirtualBox : USB Tablet (80ee:0021)
 </code></pre>
 
-- Bind usb device to usbip stub
+- Bind USB device to usbip stub
   - This command replaces an existing function driver with usbip stub driver
-  - Should be executed with an administrator privilege
-  - usbip bind -b 1-59
-  - usbip\_stub.inx, usbip\_stub.sys files should be exist in the same folder with usbip.exe
+	- This should be executed using administrator privilege
+	- usbip\_stub.inx and usbip\_stub.sys files should be in the same folder as usbip.exe
+  - usbip.exe bind -b 1-59
 - Run usbipd.exe
   - usbipd.exe -d -4
-  - TCP port 3240 should be allowed by firewall
+	- TCP port 3240 should be allowed by firewall
 
-- Attach usbip device on linux machine
+- Attach USB/IP device on linux machine
   - \# usbip attach -r &lt;usbip server ip&gt; -p 1-59
 
-### USBIP client
+### Windows USB/IP client
 
-- Prepare a linux machine as a usbip server
+- Prepare a linux machine as a USB/IP server
   - tested on Ubuntu 16.04(Kernerl 4.15.0-29)
   - \# modprobe usbip-host
 
-- Run usbipd on a usbip server(Linux)
+- Run usbipd on a USB/IP server(Linux)
   - \# usbipd -4 -d
 
-- Install USBIP test certificate
+- Install USB/IP test certificate
   - Install driver/usbip\_test.pfx(password: usbip)
   - Certificate should be installed into "Trusted Root Certification Authority" on local machine(not current user)
 - Enable test signing
+  - bcdedit.exe /set TESTSIGNING ON
+  - reboot the system to apply
 - Copy usbip.exe, usbip\_vhci.sys, usbip\_vhci.inf, usbip\_vhci.cer, usbip\_vhci.cat into a folder in target machine
   - You can find usbip.exe, usbip\_vhci.sys, usbip\_vhci.cer, usbip\_vhci.inf in output folder.
   - usbip\_vhci.cat can be found from usbip\_vhci subfolder of output folder
-- Install USBIP vhci driver
-  - Start a device manager
+- Install USB/IP vhci driver
+  - Start Device manager
   - Choose "Add Legacy Hardware" from the "Action" menu.
   - Select 'Install the hardware that I manually select from the list'.
   - Click 'Next'.
@@ -95,7 +97,7 @@
   - Click on the 'USB/IP VHCI, and then click Next.
   - Click Finish at 'Completing the Add/Remove Hardware Wizard.'
 - Attach a remote USB device
-  - C:\usbip.exe attach -r &lt;usbip server ip&gt; -b 2-2
+  - usbip.exe attach -r &lt;usbip server ip&gt; -b 2-2
 
 <hr>
 <sub>This project was supported by Basic Science Research Program through the National Research Foundation of Korea(NRF) funded by the Ministry of Education(2016R1A6A3A11930295).</sub>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Build Tools
 - Visual Studio 2017 Community
 - Windows SDK 10.0.17134
-- Windows Driver Kit 10.0.17134
+- Windows Driver Kit 10.0.17763
 
 ### Build Process
 - Open usbip_win.sln

--- a/driver/lib/libdrv.vcxproj
+++ b/driver/lib/libdrv.vcxproj
@@ -33,7 +33,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>usbip</RootNamespace>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -140,7 +140,7 @@
       <WppRecorderEnabled>true</WppRecorderEnabled>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <WppKernelMode>true</WppKernelMode>
-      <AdditionalIncludeDirectories>..\..\include;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;$(IntDir);$(DDK_INC_PATH);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)wdmsec.lib;$(DDK_LIB_PATH)ntstrsafe.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/driver/stub/usbip_stub.vcxproj
+++ b/driver/stub/usbip_stub.vcxproj
@@ -55,7 +55,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>usbip</RootNamespace>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -162,7 +162,7 @@
       <WppRecorderEnabled>true</WppRecorderEnabled>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <WppKernelMode>true</WppKernelMode>
-      <AdditionalIncludeDirectories>..\..\include;..\lib;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;..\lib;$(IntDir);$(DDK_INC_PATH);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)wdmsec.lib;$(DDK_LIB_PATH)ntstrsafe.lib;$(DDK_LIB_PATH)usbd.lib;$(DDK_LIB_PATH)usbdex.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/driver/vhci/usbip_vhci.vcxproj
+++ b/driver/vhci/usbip_vhci.vcxproj
@@ -57,7 +57,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>usbip</RootNamespace>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -164,7 +164,7 @@
       <WppRecorderEnabled>true</WppRecorderEnabled>
       <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">trace.h</WppScanConfigurationData>
       <WppKernelMode>true</WppKernelMode>
-      <AdditionalIncludeDirectories>..\..\include;..\lib;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;..\lib;$(IntDir);$(DDK_INC_PATH);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)wdmsec.lib;$(DDK_LIB_PATH)ntstrsafe.lib;usbd.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/userspace/lib/usbip_common.vcxproj
+++ b/userspace/lib/usbip_common.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2C173853-88C0-4334-85BF-0B46CFD5A007}</ProjectGuid>
     <RootNamespace>usbip_common</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/userspace/src/stubctl/stubctl.vcxproj
+++ b/userspace/src/stubctl/stubctl.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{184FB594-E18D-4B2E-AA9C-2F2A7D65ADA5}</ProjectGuid>
     <RootNamespace>usbip</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/userspace/src/usbip/usbip.vcxproj
+++ b/userspace/src/usbip/usbip.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{36CEE68D-D6CF-4413-978C-794488F44555}</ProjectGuid>
     <RootNamespace>usbip</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/userspace/src/usbipd/usbipd.vcxproj
+++ b/userspace/src/usbipd/usbipd.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{0C5C92AA-37F0-4521-86EA-76F32B43E7B4}</ProjectGuid>
     <RootNamespace>usbipd</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Clarified and fixed README.md.
Updated Windows driver kit requirement to latest version (10.0.1763). Previous version should still work, but you will need to change the version in the VS projects.