### PR TITLE
Correctly calculate NEXT_USBD_INTERFACE_INFO to avoid an underflow

### DIFF
--- a/driver/vhci/vhci_devconf.c
+++ b/driver/vhci/vhci_devconf.c
@@ -6,8 +6,8 @@
 #include "usbip_vhci_api.h"
 #include "usbip_proto.h"
 
-#define NEXT_USBD_INTERFACE_INFO(info_intf)	(USBD_INTERFACE_INFORMATION *)((PUINT8)(info_intf + 1) + \
-		((info_intf)->NumberOfPipes - 1) * sizeof(USBD_PIPE_INFORMATION))
+#define NEXT_USBD_INTERFACE_INFO(info_intf)	(USBD_INTERFACE_INFORMATION *)((PUINT8)(info_intf + 1) - \
+	(1 * sizeof(USBD_PIPE_INFORMATION)) + (info_intf->NumberOfPipes * sizeof(USBD_PIPE_INFORMATION)));
 
 #define MAKE_PIPE(ep, type, interval) ((USBD_PIPE_HANDLE)((ep) | ((interval) << 8) | ((type) << 16)))
 #define TO_INTF_HANDLE(intf_num, altsetting)	((USBD_INTERFACE_HANDLE)((intf_num << 8) + altsetting))


### PR DESCRIPTION
This fixes iterating over interface with no endpoints/pipes

This allows setup like USB audio + USB HID to work, which has an initial interface without endpoint.
Many products are probably fixed with this change, as all multi-interface devices with (at least) audio are affected.

The actual bug is the calculation of the structure size in the NEXT_USBD_INTERFACE_INFO macro.
The _USBD_INTERFACE_INFORMATION structure has an open array of 1, which is there because older compilers that does not support zero sized arrays in structs.

To fix this simply subtract the extra USBD_PIPE_INFORMATION _before_ calculating the number of pipe to jump forward.

It is fortunate that it did not crash the system. It some cases it might. But since the overflow almost always results in -1,-2,-3 you just get a wrap-around minus a few.