### PR TITLE
Typo bugfix in Device name: Pid --> PID, Vid --> VID

### DIFF
--- a/driver/vhci/vhci_vpdo.c
+++ b/driver/vhci/vhci_vpdo.c
@@ -219,7 +219,7 @@ setup_vpdo_device_id(pusbip_vpdo_dev_t vpdo, PIRP irp)
 	if (id_dev == NULL) {
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
-	RtlStringCchPrintfW(id_dev, 22, L"USB\\Vid_%04hx&Pid_%04hx", vpdo->vendor, vpdo->product);
+	RtlStringCchPrintfW(id_dev, 22, L"USB\\VID_%04hx&PID_%04hx", vpdo->vendor, vpdo->product);
 	irp->IoStatus.Information = (ULONG_PTR)id_dev;
 	return STATUS_SUCCESS;
 }
@@ -247,8 +247,8 @@ setup_vpdo_hw_ids(pusbip_vpdo_dev_t vpdo, PIRP irp)
 	if (ids_hw == NULL) {
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
-	RtlStringCchPrintfW(ids_hw, 31, L"USB\\Vid_%04hx&Pid_%04hx&Rev_%04hx", vpdo->vendor, vpdo->product, vpdo->revision);
-	RtlStringCchPrintfW(ids_hw + 31, 22, L"USB\\Vid_%04hx&Pid_%04hx", vpdo->vendor, vpdo->product);
+	RtlStringCchPrintfW(ids_hw, 31, L"USB\\VID_%04hx&PID_%04hx&Rev_%04hx", vpdo->vendor, vpdo->product, vpdo->revision);
+	RtlStringCchPrintfW(ids_hw + 31, 22, L"USB\\VID_%04hx&PID_%04hx", vpdo->vendor, vpdo->product);
 	ids_hw[53] = L'\0';
 	irp->IoStatus.Information = (ULONG_PTR)ids_hw;
 	return STATUS_SUCCESS;


### PR DESCRIPTION
On windows, the device name contains ProductID (PID) and VendorID (VID).

It's common idiom to use upporcase for Product/Vendor IDs.

In USBIP VHCI driver the PID is noted as "Pid" and VID as "Vid". This can break
some services/drivers which watch on incomming USB devices and parse
Device Name.