### PR TITLE
usbip_forward should wait a small amount of time if an async read is canceled before tearing down the thread

### DIFF
--- a/userspace/lib/usbip_forward.c
+++ b/userspace/lib/usbip_forward.c
@@ -602,10 +602,15 @@ usbip_forward(HANDLE hdev_src, HANDLE hdev_dst, BOOL inbound)
 
 	/* Cancel an uncompleted asynchronous read */
 	/* If there's no asynchronous read pending, CancelIo seems to be blocked. */
-	if (buff_src.in_reading)
+	if (buff_src.in_reading) {
 		CancelIoEx(hdev_src, &buff_src.ovs[0]);
-	if (buff_dst.in_reading)
+		SleepEx(500, TRUE);
+	}
+	
+	if (buff_dst.in_reading) {
 		CancelIoEx(hdev_dst, &buff_dst.ovs[0]);
+		SleepEx(500, TRUE);
+	}
 
 	cleanup_devbuf(&buff_src);
 	cleanup_devbuf(&buff_dst);

--- a/userspace/src/usbipd/usbipd_list.c
+++ b/userspace/src/usbipd/usbipd_list.c
@@ -48,7 +48,7 @@ walker_edev_list(HDEVINFO dev_info, PSP_DEVINFO_DATA pdev_info_data, devno_t dev
 		return 0;
 	}
 	if (!build_udev(devno, &edev->udev)) {
-		err("%s: cannot build usbip dev", __FUNCTION__);
+		dbg("%s: cannot build usbip dev", __FUNCTION__);
 		free(edev);
 		return 0;
 	}

--- a/userspace/src/usbipd/usbipd_stub.c
+++ b/userspace/src/usbipd/usbipd_stub.c
@@ -131,7 +131,7 @@ build_udev(devno_t devno, struct usbip_usb_device *pudev)
 
 	devpath = get_devpath_from_devno(devno);
 	if (devpath == NULL) {
-		err("%s: invalid devno: %hhu. devpath returned %s", __FUNCTION__, devno, devpath);
+		dbg("%s: invalid devno: %hhu. devpath returned %s", __FUNCTION__, devno, devpath);
 		return FALSE;
 	}
 


### PR DESCRIPTION
From Oxalin: I'm adding a little context if someone needs to go through this.

From #59 "[...] usbipd incurs seg fault at the rbuff check line when a forwarding routine of usbipd stops as you pointed out. But this fault is raised by not only disconnection and also detaching. In my opinion, it is due to that the forwarding routine does not clean up asynchronous I/O even though CancelIoEx is invoked before the forwarding routine exits."